### PR TITLE
US2: Send an email to user after bonita deployment

### DIFF
--- a/bonita/README.md
+++ b/bonita/README.md
@@ -4,3 +4,6 @@ This Ansible script locally installs and starts Bonita CE Tomcat bundle with def
 Prerequisite: Ansible 2.9> is installed locally, Java 8 is installed locally. 
 
 To execute the script, copy `BonitaCommunity-7.9.4-tomcat.zip` into the same directory as the playbook then run: `ansible-playbook deploy-bonita.yml`.
+
+You will have to manually enter email address of the user you want to notify when Bonita is deployed, or add the `-e usermail=<user email>` option at launch.
+

--- a/bonita/deploy-bonita.yml
+++ b/bonita/deploy-bonita.yml
@@ -4,6 +4,10 @@
     workdir: "{{ playbook_dir }}"
     archive: "{{ workdir }}/BonitaCommunity-7.9.4-tomcat.zip"
     installdir: "{{ workdir }}/BonitaCommunity-7.9.4-tomcat"
+  vars_prompt:
+    - name: usermail
+      prompt: "What is the email address of the user you want to notify when deployment is done?"
+      private: no
   tasks:
   - set_fact: password="{{ lookup('password', '/dev/null length=16 chars=ascii_letters,digits') }}"
   - name: Check Bonita Tomcat bundle installed
@@ -49,3 +53,16 @@
     wait_for:
       port: 8080
       timeout: 60
+  - name: Sending Bonita credentials to user email
+    mail:
+      host: smtp.gmail.com
+      port: 587
+      from: noreply@bonitasoft.com
+      username: foo@gmail.com
+      password: foogmailpassword
+      to: "{{ usermail }}"
+      subject: Bonita CE up and running on {{ inventory_hostname }}
+      body: Your bonita instance is accessible at http://{{ inventory_hostname }}:8080/bonita with credentials install / {{ password }}
+      secure: starttls
+      charset: utf-8
+


### PR DESCRIPTION
**US2**: As a community member, I want to be notified by email when my new environment has been created by the system admin

**Acceptance criteria**:

- a notification by email must be sent to customer with login information
- when I click on the provided link, my web browser opens the Bonita Login page
- when I enter the credentials 'Install' / <password provided in the email> I am able to login onto Bonita Portal.
- This automatic email notification must be implemented with in Ansible
